### PR TITLE
[fix] url id값 추출하는 정규표현식 추가

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,10 +13,8 @@
         <a href="/design" id="design">디자인</a>
         <a href="/development" id="development">개발</a>
         <a href="/recruit" id="recruit">채용</a>
-        </header>
-        <main></main>
-        <script type="module" src="/src/js/index.js"></script>
-
-
+    </header>
+    <main></main>
+    <script type="module" src="/src/js/index.js"></script>
 </body>
 </html>

--- a/src/js/404.js
+++ b/src/js/404.js
@@ -1,5 +1,5 @@
 const notFound = () => {
-    console.log("not found 404")
+    console.log("not found 404입니다")
 }
 
 export default notFound;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,30 +1,58 @@
 import homePage from './home.js';
 import postPage from './post.js';
+import designPage from './design.js';
 import notFound from './404.js';
 
 const HEADER = document.getElementById("header")
 const MAIN = document.querySelector("main")
-// const pathToRegex = path => new RegExp("^" + path.replace(/\//g, "\\/").replace(/:\w+/g, "(.+)") + "$")
 
 const routes = [
-    {path: "/", component: homePage },
-    {path: "/post:id", component: postPage },
-    // {path: "/design", component: designPage },
-    // {path: "/desgin:id", component: designPage },
+  {path: "/", component: homePage },
+  {path: "/post/:id", component: postPage },
+  {path: "/design", component: designPage },
 ]
 
-console.log("index3.js ok")
+const pathToRegex = path => new RegExp("^" + path.replace(/\//g, "\\/").replace(/:\w+/g, "(.+)") + "$")
 
-const router = async path => {
-    const _path = path ?? window.location.pathname;
-    console.log("_path is: ",_path)
-    try {
-      const component = routes.find(route => route.path === _path)?.component || notFound;
-      MAIN.replaceChildren(await component());
+const router = async () => {
+    const _path = window.location.pathname;
+    const matchedRoute = routes.map(route => {
+      return _path.match(pathToRegex(route.path))
+    })
+    const notNullRoute =  matchedRoute.find( route => route !== null) 
+    const componentFunc = (dataId) => {
+      if(dataId) {
+        routes.find(route => route.path === notNullRoute[0])?.component(dataId) || notFound()
+      } else {
+        routes.find(route => route.path === notNullRoute[0])?.component() || notFound() 
+      }
+    };
+    // const render = routes.find(route => route.path === location.pathname)?.component || notFound
+    const showComponent = async (id) => {
+      if (id){
+        console.log("id 있음 ",id)
+        MAIN.replaceChildren(await componentFunc(id));
+      } else {
+        console.log("id 없음")
+        MAIN.replaceChildren(await componentFunc());
+      }
+    }
+
+  try {
+      console.log("notNullRoute:", notNullRoute)
+      // const component = routes.find(route => route.path === notNullRoute[0])?.component || notFound;      
+      // MAIN.replaceChildren(await showComponent(notNullRoute[1]));
+      if (typeof(notNullRoute[1]) === 'string') {
+        showComponent(notNullRoute[1])
+      } else {
+        showComponent()
+      }
     } catch (err) {
       console.error(err);
     }
   };
+
+
 
 HEADER.addEventListener("click", (e)=>{
     if (!e.target.matches(" header > a ")){
@@ -32,19 +60,18 @@ HEADER.addEventListener("click", (e)=>{
     }
     e.preventDefault();
     const pathHref = e.target.getAttribute('href');
-
     if (window.location.pathname === pathHref) return;
-
     window.history.pushState(null, null, pathHref);
-
-    router(pathHref)
+    router()
 })
+
 
 
 window.addEventListener('popstate', () => {
     router();
   });
 
-window.addEventListener('DOMContentLoaded', ()=> {router()});
+window.addEventListener('DOMContentLoaded', ()=> {router()
+});
 
 

--- a/src/js/pageHandler.js
+++ b/src/js/pageHandler.js
@@ -1,0 +1,23 @@
+const pageHandler = async (params) => {
+
+    const {id} = params;
+    
+    await fetch("/src/data/postData.json")
+        .then(response => response.json())
+        .then(data => {
+            const idMatchedData = data.find(item => item.id = id) 
+            console.log("idMatchedData:",idMatchedData)
+
+            const posting = document.createElement("div");
+                posting.innerHTML = `
+                    <div>
+                        <img src="${idMatchedData.src}" alt="${idMatchedData.title}">
+                        <h2>${idMatchedData.title}  ${idMatchedData.id}</h2>
+                        <p>${idMatchedData.desc}</p>
+                        <p>Date: ${idMatchedData.date}</p>
+                    </div>
+                `
+                document.querySelector("main").append(posting);
+        })
+    }
+    export default pageHandler;

--- a/src/js/post.js
+++ b/src/js/post.js
@@ -1,0 +1,9 @@
+const post =  (postId) => {
+    console.log("상세페이지 ok", postId)
+    // const data = await fetch("/src/data/postData.json")
+    // const res = data.json()
+    // console.log(res)
+    // const filterdId = data.filter((item)=>item.id = id)    
+}
+
+export default post;


### PR DESCRIPTION

[issue4번 질문](https://github.com/ny-plus-ny/frameworkless-js/issues/4)을 위해 현재 진행상황까지 포함한 PR입니다.
Closed #4 

</br>


**현재상황**
- getURL 을 사용하여 location.pathname에 맞는 id 값의 data 가져오기 완료
- href 변경될 때 새로고침 자동으로 되지 않음.
- home의 게시글 리스트에서 게시글 클릭했을 때  게시글의 id에 맞는 데이터가 들어오지 않음.

</br>

**참고사항**
`nopeNullRoute` 
-  `result`에는 routes.path와 일치하는 location.pathname 값을, 
-  `route`에는 routes에서 map을 돌때의 요소를 담았습니다.

<img width="572" alt="image" src="https://github.com/ny-plus-ny/frameworkless-js/assets/102043741/441ab366-c77d-4d15-95b5-d3587c807522">
